### PR TITLE
Configure Swagger for JWT admin header

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using EcommerceBackend.Helpers;
 using EcommerceBackend.Services.Implementations;
 using EcommerceBackend.Services.Interfaces;
 using EcommerceBackend.Hubs;
+using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -16,7 +17,33 @@ builder.Services.AddControllers();
 builder.Services.AddHttpContextAccessor();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "Bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Enter 'Bearer <token>'",
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            new string[] {}
+        }
+    });
+});
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # EcommerceBackend
+
+This project provides the backend API for an e-commerce application built with ASP.NET Core.
+
+## Using Swagger
+
+When running in development mode, Swagger UI is available for testing the API. Some endpoints require admin authorization. To access these endpoints, click the **Authorize** button in Swagger UI and provide a JWT token using the following format:
+
+```
+Authorization: Bearer <valid-admin-token>
+```
+
+Replace `<valid-admin-token>` with a valid JWT for a user in the `Admin` role.


### PR DESCRIPTION
## Summary
- configure Swagger to display the JWT Authorization header
- document how to use the admin token in Swagger

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a7e3a26483258da01b8d6da9bb0d